### PR TITLE
Add JSON output and favorites spotlight to meta guide CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,54 @@
+# College Football Meta Guide
+
+This project provides a command line tool for monitoring college football games in progress.
+It aggregates TV channel assignments, highlights close games late in the second half, and
+ranks matchups to help decide which game to watch.
+
+## Features
+
+* Fetches the ESPN college football scoreboard for a specific date (defaults to today).
+* Normalizes each game into structured data that includes team names, TV broadcasts, start
+  time, and live status information.
+* Computes an "interest" score that favors ranked matchups and especially games that are
+  close in the 3rd or 4th quarter.
+* Renders a compact table that can be sorted by interest score or filtered to only show
+  live games.
+* Can operate offline by pointing to a stored JSON scoreboard snapshot, enabling
+  repeatable testing.
+
+## Installation
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -e .
+```
+
+## Usage
+
+```bash
+cfbmeta --date 20231021 --top 8
+```
+
+### CLI Options
+
+* `--date YYYYMMDD` – Fetches the scoreboard for the given date.
+* `--scoreboard PATH` – Uses a local ESPN scoreboard JSON file instead of fetching from
+  the network.
+* `--only-live` – Shows only games that are currently in progress.
+* `--top N` – Limits the output to the top `N` games by interest score.
+* `--show-all` – Displays the full scoreboard instead of only ranked games.
+
+Running `cfbmeta --help` prints the full list of options.
+
+## Development
+
+Install the development dependencies and run the tests:
+
+```bash
+pip install -e .[dev]
+pytest
+```
+
+The project intentionally separates data fetching from analytics so that tests can run
+entirely against the bundled sample scoreboard snapshot in `tests/data`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,24 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "cfbmeta"
+version = "0.1.0"
+description = "College football TV and scoreboard meta guide"
+authors = [{name = "Code Assistant"}]
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = []
+
+[project.optional-dependencies]
+dev = [
+  "pytest>=7.4",
+]
+
+[project.scripts]
+cfbmeta = "cfbmeta.cli:main"
+
+[tool.pytest.ini_options]
+addopts = "-q"
+testpaths = ["tests"]

--- a/src/cfbmeta/__init__.py
+++ b/src/cfbmeta/__init__.py
@@ -1,0 +1,13 @@
+"""College football meta guide package."""
+
+from .models import Game, TeamScore
+from .analysis import build_game_summary, interest_score
+from .data_fetcher import load_scoreboard
+
+__all__ = [
+    "Game",
+    "TeamScore",
+    "build_game_summary",
+    "interest_score",
+    "load_scoreboard",
+]

--- a/src/cfbmeta/analysis.py
+++ b/src/cfbmeta/analysis.py
@@ -1,0 +1,98 @@
+"""Scoring and formatting logic for the meta guide."""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+from datetime import datetime, timezone
+from typing import Iterable, List, Sequence
+
+from .models import Game
+
+
+def interest_score(game: Game, now: datetime | None = None) -> float:
+    """Computes a heuristic score describing how watchable a game is."""
+
+    score = 0.0
+    if game.home.rank or game.away.rank:
+        ranked_bonus = 5.0
+        if game.home.rank and game.away.rank:
+            ranked_bonus += 5.0
+        score += ranked_bonus
+
+    if game.is_live:
+        score += 40.0
+        if game.period >= 3:
+            score += 15.0
+            score += max(0.0, 20.0 - 2.5 * game.score_margin)
+        else:
+            score += max(0.0, 8.0 - 1.0 * game.score_margin)
+        score += _pace_bonus(game)
+    elif game.is_final:
+        score += 5.0  # recaps for finished thrillers
+        score += max(0.0, 20.0 - 2.5 * game.score_margin)
+    else:
+        score += 2.0  # future games
+
+    if now is None:
+        now = datetime.now(timezone.utc)
+    kickoff_delta = (game.start_time - now).total_seconds() / 3600.0
+    if kickoff_delta > 0:
+        score += max(0.0, 6.0 - kickoff_delta)  # near-future kickoffs
+    elif -2.5 < kickoff_delta <= 0 and not game.is_live:
+        score += 3.0  # recently completed
+
+    return round(score, 2)
+
+
+def _pace_bonus(game: Game) -> float:
+    pace_lookup = {
+        "0:00": 0.0,
+        "0:01": 0.0,
+    }
+    if game.clock in pace_lookup:
+        return pace_lookup[game.clock]
+    if not game.clock:
+        return 0.0
+    try:
+        minutes, seconds = map(int, game.clock.split(":"))
+        total_seconds = minutes * 60 + seconds
+    except ValueError:
+        return 0.0
+    if total_seconds < 120:
+        return 8.0
+    if total_seconds < 300:
+        return 4.0
+    return 0.0
+
+
+def build_game_summary(game: Game, include_notes: bool = False) -> str:
+    parts: List[str] = []
+    teams = f"{game.away.abbreviation} {game.away.score} @ {game.home.abbreviation} {game.home.score}"
+    parts.append(teams)
+    status = game.status
+    if game.is_live:
+        status = f"Q{game.period} {game.clock}"
+    parts.append(status)
+    if game.broadcasts:
+        parts.append("TV: " + ", ".join(game.broadcasts))
+    if include_notes and game.notes:
+        parts.extend(game.notes)
+    return " | ".join(parts)
+
+
+def summarize_games(games: Sequence[Game], include_notes: bool = False) -> List[dict]:
+    summaries: List[dict] = []
+    for game in games:
+        data = asdict(game)
+        data["start_time"] = game.start_time.isoformat()
+        data["interest"] = interest_score(game)
+        data["summary"] = build_game_summary(game, include_notes=include_notes)
+        summaries.append(data)
+    return summaries
+
+
+def select_top_games(games: Iterable[Game], limit: int | None = None) -> List[Game]:
+    ranked = sorted(games, key=interest_score, reverse=True)
+    if limit is None:
+        return ranked
+    return ranked[:limit]

--- a/src/cfbmeta/cli.py
+++ b/src/cfbmeta/cli.py
@@ -1,0 +1,145 @@
+"""Command line interface for the college football meta guide."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable, List, Sequence
+
+from .analysis import (
+    build_game_summary,
+    interest_score,
+    select_top_games,
+    summarize_games,
+)
+from .data_fetcher import ScoreboardLoadError, load_scoreboard
+from .models import Game, parse_games
+
+
+def parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--date", help="YYYYMMDD date for the scoreboard")
+    parser.add_argument(
+        "--scoreboard",
+        help="Path to a saved ESPN scoreboard JSON file (bypasses network fetch)",
+    )
+    parser.add_argument("--top", type=int, default=10, help="Limit the number of games shown")
+    parser.add_argument(
+        "--only-live",
+        action="store_true",
+        help="Only show games that are currently in progress",
+    )
+    parser.add_argument(
+        "--include-notes",
+        action="store_true",
+        help="Include odds/headlines in the output",
+    )
+    parser.add_argument(
+        "--show-all",
+        action="store_true",
+        help="Do not filter the scoreboard when ranking games",
+    )
+    parser.add_argument(
+        "--favorites",
+        help="Comma separated team names or abbreviations to keep in view",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("text", "json"),
+        default="text",
+        help="Output format for the ranked games",
+    )
+    parser.add_argument(
+        "--output",
+        help="Optional file path to write the results (defaults to stdout)",
+    )
+    return parser.parse_args(list(argv) if argv is not None else None)
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        scoreboard = load_scoreboard(date=args.date, scoreboard_path=args.scoreboard)
+    except ScoreboardLoadError as exc:
+        print(f"Error: {exc}")
+        return 1
+
+    favorites = _parse_favorites(args.favorites)
+
+    games = list(parse_games(scoreboard))
+    if args.only_live:
+        games = [g for g in games if g.is_live or _is_favorite(g, favorites)]
+    if not args.show_all:
+        games = [
+            g
+            for g in games
+            if g.is_live or g.home.rank or g.away.rank or _is_favorite(g, favorites)
+        ]
+
+    ranked_games = select_top_games(games, limit=args.top)
+
+    if args.format == "json":
+        return _emit_json(ranked_games, favorites, args)
+
+    now = datetime.now(timezone.utc)
+    rows: List[str] = []
+    for game in ranked_games:
+        summary = build_game_summary(game, include_notes=args.include_notes)
+        if _is_favorite(game, favorites):
+            summary = "★ " + summary
+        rows.append(f"[{interest_score(game, now=now):5.2f}] {summary}")
+
+    if not rows:
+        return _write_output("No games matched the filters.", args.output)
+
+    header = "College Football Meta Guide\n" + "=" * 32
+    body = "\n".join(rows)
+    text = f"{header}\n{body}"
+    return _write_output(text, args.output)
+
+
+def _emit_json(
+    games: Sequence[Game], favorites: Sequence[str], args: argparse.Namespace
+) -> int:
+    summaries = summarize_games(games, include_notes=args.include_notes)
+    for entry, game in zip(summaries, games):
+        entry["is_favorite"] = _is_favorite(game, favorites)
+    payload = {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "games": summaries,
+    }
+    json_text = json.dumps(payload, indent=2)
+    return _write_output(json_text, args.output)
+
+
+def _write_output(text: str, output_path: str | None) -> int:
+    if output_path:
+        Path(output_path).write_text(text + ("\n" if not text.endswith("\n") else ""))
+    else:
+        print(text)
+    return 0
+
+
+def _parse_favorites(raw: str | None) -> List[str]:
+    if not raw:
+        return []
+    return [token.strip().casefold() for token in raw.split(",") if token.strip()]
+
+
+def _is_favorite(game: Game, favorites: Sequence[str]) -> bool:
+    if not favorites:
+        return False
+
+    identifiers = {
+        game.home.abbreviation.casefold(),
+        game.away.abbreviation.casefold(),
+        game.home.name.casefold(),
+        game.away.name.casefold(),
+    }
+    return any(fav in identifiers for fav in favorites)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    raise SystemExit(main())

--- a/src/cfbmeta/data_fetcher.py
+++ b/src/cfbmeta/data_fetcher.py
@@ -1,0 +1,49 @@
+"""Utilities to load the ESPN college football scoreboard."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import json
+from urllib import request, parse
+
+SCOREBOARD_URL = "https://site.api.espn.com/apis/site/v2/sports/football/college-football/scoreboard"
+
+
+class ScoreboardLoadError(RuntimeError):
+    """Raised when a scoreboard cannot be loaded."""
+
+
+def load_scoreboard(date: Optional[str] = None, scoreboard_path: Optional[str] = None) -> Dict[str, Any]:
+    """Loads a scoreboard either from disk or via the ESPN API.
+
+    Args:
+        date: Optional YYYYMMDD date string. Required when fetching from the network.
+        scoreboard_path: Optional path to a JSON file to load instead of fetching.
+
+    Returns:
+        Parsed JSON dictionary containing scoreboard data.
+    """
+
+    if scoreboard_path:
+        return _load_from_path(scoreboard_path)
+
+    params = {"limit": "300"}
+    if date:
+        params["dates"] = date
+    url = SCOREBOARD_URL + "?" + parse.urlencode(params)
+    try:
+        with request.urlopen(url, timeout=10) as response:  # pragma: no cover - network
+            data = response.read().decode("utf-8")
+    except Exception as exc:  # pragma: no cover - network errors
+        raise ScoreboardLoadError("Unable to fetch scoreboard") from exc
+
+    return json.loads(data)
+
+
+def _load_from_path(path: str) -> Dict[str, Any]:
+    file_path = Path(path)
+    if not file_path.exists():
+        raise ScoreboardLoadError(f"Scoreboard file not found: {path}")
+    return json.loads(file_path.read_text(encoding="utf-8"))

--- a/src/cfbmeta/models.py
+++ b/src/cfbmeta/models.py
@@ -1,0 +1,141 @@
+"""Domain models for college football games."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Iterable, List, Optional, Sequence
+
+
+
+@dataclass
+class TeamScore:
+    """Represents a team's score and metadata."""
+
+    name: str
+    abbreviation: str
+    score: int
+    record: Optional[str] = None
+    rank: Optional[int] = None
+
+
+@dataclass
+class Game:
+    """Normalized representation of a college football game."""
+
+    id: str
+    start_time: datetime
+    status: str
+    period: int
+    clock: str
+    is_live: bool
+    venue: Optional[str]
+    broadcasts: Sequence[str]
+    home: TeamScore
+    away: TeamScore
+    notes: List[str] = field(default_factory=list)
+
+    @property
+    def score_margin(self) -> int:
+        return abs(self.home.score - self.away.score)
+
+    @property
+    def is_final(self) -> bool:
+        return "final" in self.status.lower()
+
+    @property
+    def winner(self) -> Optional[TeamScore]:
+        if not self.is_final:
+            return None
+        if self.home.score == self.away.score:
+            return None
+        return self.home if self.home.score > self.away.score else self.away
+
+    @classmethod
+    def from_espn_event(cls, event: dict) -> "Game":
+        competition = event["competitions"][0]
+        status = competition["status"]["type"]
+        competitors = competition["competitors"]
+        home_data = next(c for c in competitors if c["homeAway"] == "home")
+        away_data = next(c for c in competitors if c["homeAway"] == "away")
+
+        def _team_score(data: dict) -> TeamScore:
+            team = data["team"]
+            rank = team.get("rank")
+            return TeamScore(
+                name=team.get("displayName") or team.get("name"),
+                abbreviation=team.get("abbreviation", ""),
+                score=int(data.get("score", 0)),
+                record=next((rec.get("summary") for rec in data.get("records", [])), None),
+                rank=int(rank) if rank is not None else None,
+            )
+
+        start_time = _parse_datetime(competition["date"])
+        broadcasts = _broadcasts(competition)
+
+        return cls(
+            id=event.get("id") or competition.get("id"),
+            start_time=start_time,
+            status=status.get("name", "STATUS_UNKNOWN"),
+            period=int(status.get("period", 0)),
+            clock=status.get("displayClock", ""),
+            is_live=status.get("state") == "in",
+            venue=_venue_name(competition),
+            broadcasts=broadcasts,
+            home=_team_score(home_data),
+            away=_team_score(away_data),
+            notes=_build_notes(status, competition),
+        )
+
+
+def _broadcasts(competition: dict) -> Sequence[str]:
+    broadcasts = competition.get("broadcasts") or []
+    names: List[str] = []
+    for broadcast in broadcasts:
+        if broadcast.get("media") != "TV":
+            continue
+        for name in broadcast.get("names", []):
+            if name not in names:
+                names.append(name)
+    if not names and competition.get("geoBroadcasts"):
+        for geo in competition["geoBroadcasts"]:
+            media = geo.get("media")
+            if media and media.get("type") == "TV" and geo.get("type", {}).get("shortName"):
+                channel = f"{geo['type']['shortName']} {media.get('channel', '').strip()}".strip()
+                if channel and channel not in names:
+                    names.append(channel)
+    return names
+
+
+def _venue_name(competition: dict) -> Optional[str]:
+    venue = competition.get("venue") or {}
+    return venue.get("fullName")
+
+
+def _build_notes(status: dict, competition: dict) -> List[str]:
+    notes: List[str] = []
+    if status.get("state") == "pre":
+        if competition.get("odds"):
+            odds_text = competition["odds"][0].get("details")
+            if odds_text:
+                notes.append(odds_text)
+    headlines = competition.get("headlines") or []
+    if headlines:
+        primary = headlines[0]
+        if primary.get("shortLinkText"):
+            notes.append(primary["shortLinkText"])
+    return notes
+
+
+def parse_games(scoreboard: dict) -> Iterable[Game]:
+    for event in scoreboard.get("events", []):
+        try:
+            yield Game.from_espn_event(event)
+        except Exception:  # pragma: no cover - guard against unexpected API changes
+            continue
+
+
+def _parse_datetime(value: str) -> datetime:
+    if value.endswith('Z'):
+        value = value[:-1] + '+00:00'
+    return datetime.fromisoformat(value).astimezone(timezone.utc)

--- a/tests/data/espn_scoreboard_sample.json
+++ b/tests/data/espn_scoreboard_sample.json
@@ -1,0 +1,208 @@
+{
+  "events": [
+    {
+      "id": "401514123",
+      "competitions": [
+        {
+          "id": "401514123",
+          "date": "2023-10-21T23:30Z",
+          "status": {
+            "type": {
+              "name": "STATUS_IN_PROGRESS",
+              "state": "in",
+              "period": 4,
+              "displayClock": "02:15"
+            }
+          },
+          "broadcasts": [
+            {
+              "media": "TV",
+              "names": ["ESPN"]
+            }
+          ],
+          "competitors": [
+            {
+              "homeAway": "home",
+              "score": "24",
+              "team": {
+                "displayName": "Oregon Ducks",
+                "abbreviation": "ORE",
+                "rank": 9
+              },
+              "records": [
+                {"summary": "6-1"}
+              ]
+            },
+            {
+              "homeAway": "away",
+              "score": "21",
+              "team": {
+                "displayName": "Washington State Cougars",
+                "abbreviation": "WSU"
+              },
+              "records": [
+                {"summary": "5-2"}
+              ]
+            }
+          ],
+          "venue": {"fullName": "Autzen Stadium"},
+          "headlines": [
+            {"shortLinkText": "Ducks convert late fourth down"}
+          ]
+        }
+      ]
+    },
+    {
+      "id": "401514200",
+      "competitions": [
+        {
+          "id": "401514200",
+          "date": "2023-10-21T22:00Z",
+          "status": {
+            "type": {
+              "name": "STATUS_IN_PROGRESS",
+              "state": "in",
+              "period": 3,
+              "displayClock": "08:45"
+            }
+          },
+          "broadcasts": [
+            {
+              "media": "TV",
+              "names": ["FOX"]
+            }
+          ],
+          "competitors": [
+            {
+              "homeAway": "home",
+              "score": "35",
+              "team": {
+                "displayName": "USC Trojans",
+                "abbreviation": "USC",
+                "rank": 13
+              },
+              "records": [
+                {"summary": "6-1"}
+              ]
+            },
+            {
+              "homeAway": "away",
+              "score": "10",
+              "team": {
+                "displayName": "Utah Utes",
+                "abbreviation": "UTAH",
+                "rank": 14
+              },
+              "records": [
+                {"summary": "6-1"}
+              ]
+            }
+          ],
+          "venue": {"fullName": "Los Angeles Memorial Coliseum"}
+        }
+      ]
+    },
+    {
+      "id": "401514300",
+      "competitions": [
+        {
+          "id": "401514300",
+          "date": "2023-10-22T00:00Z",
+          "status": {
+            "type": {
+              "name": "STATUS_SCHEDULED",
+              "state": "pre",
+              "period": 0,
+              "displayClock": ""
+            }
+          },
+          "broadcasts": [
+            {
+              "media": "TV",
+              "names": ["ABC"]
+            }
+          ],
+          "competitors": [
+            {
+              "homeAway": "home",
+              "score": "0",
+              "team": {
+                "displayName": "Alabama Crimson Tide",
+                "abbreviation": "BAMA",
+                "rank": 11
+              },
+              "records": [
+                {"summary": "6-1"}
+              ]
+            },
+            {
+              "homeAway": "away",
+              "score": "0",
+              "team": {
+                "displayName": "Tennessee Volunteers",
+                "abbreviation": "TENN",
+                "rank": 17
+              },
+              "records": [
+                {"summary": "5-2"}
+              ]
+            }
+          ],
+          "venue": {"fullName": "Bryant-Denny Stadium"},
+          "odds": [
+            {"details": "BAMA -7.5"}
+          ]
+        }
+      ]
+    },
+    {
+      "id": "401514400",
+      "competitions": [
+        {
+          "id": "401514400",
+          "date": "2023-10-21T20:00Z",
+          "status": {
+            "type": {
+              "name": "STATUS_FINAL",
+              "state": "post",
+              "period": 4,
+              "displayClock": "0:00"
+            }
+          },
+          "broadcasts": [
+            {
+              "media": "TV",
+              "names": ["CBS Sports Network"]
+            }
+          ],
+          "competitors": [
+            {
+              "homeAway": "home",
+              "score": "27",
+              "team": {
+                "displayName": "Air Force Falcons",
+                "abbreviation": "AF",
+                "rank": 25
+              },
+              "records": [
+                {"summary": "7-0"}
+              ]
+            },
+            {
+              "homeAway": "away",
+              "score": "24",
+              "team": {
+                "displayName": "Navy Midshipmen",
+                "abbreviation": "NAVY"
+              },
+              "records": [
+                {"summary": "3-4"}
+              ]
+            }
+          ],
+          "venue": {"fullName": "Falcon Stadium"}
+        }
+      ]
+    }
+  ]
+}

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import pytest
+
+from cfbmeta.analysis import build_game_summary, interest_score, select_top_games
+from cfbmeta.models import Game, parse_games
+from cfbmeta.data_fetcher import load_scoreboard
+
+
+@pytest.fixture(scope="module")
+def sample_games() -> list[Game]:
+    scoreboard = load_scoreboard(scoreboard_path="tests/data/espn_scoreboard_sample.json")
+    return list(parse_games(scoreboard))
+
+
+def test_parse_games(sample_games: list[Game]) -> None:
+    assert len(sample_games) == 4
+    first = sample_games[0]
+    assert first.home.name == "Oregon Ducks"
+    assert first.away.name == "Washington State Cougars"
+    assert "ESPN" in first.broadcasts
+
+
+def test_interest_high_for_close_late_game(sample_games: list[Game]) -> None:
+    game = next(g for g in sample_games if g.id == "401514123")
+    now = datetime(2023, 10, 21, 23, 45, tzinfo=timezone.utc)
+    score = interest_score(game, now=now)
+    assert score > 70
+
+
+def test_interest_lower_for_blowout(sample_games: list[Game]) -> None:
+    game = next(g for g in sample_games if g.id == "401514200")
+    now = datetime(2023, 10, 21, 23, 0, tzinfo=timezone.utc)
+    score = interest_score(game, now=now)
+    assert score < 70
+
+
+def test_final_game_has_winner_and_bonus(sample_games: list[Game]) -> None:
+    game = next(g for g in sample_games if g.id == "401514400")
+    assert game.winner is not None
+    now = datetime(2023, 10, 22, 1, 0, tzinfo=timezone.utc)
+    score = interest_score(game, now=now)
+    assert score == pytest.approx(22.5, rel=1e-3)
+
+
+def test_select_top_games_orders_by_interest(sample_games: list[Game]) -> None:
+    now = datetime(2023, 10, 21, 23, 45, tzinfo=timezone.utc)
+    ranked = select_top_games(sample_games)
+    scores = [interest_score(g, now=now) for g in ranked]
+    assert scores == sorted(scores, reverse=True)
+
+
+def test_build_game_summary_includes_tv(sample_games: list[Game]) -> None:
+    game = next(g for g in sample_games if "ESPN" in g.broadcasts)
+    summary = build_game_summary(game, include_notes=True)
+    assert "TV: ESPN" in summary
+    assert "Ducks convert" in summary

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SCOREBOARD = PROJECT_ROOT / "tests" / "data" / "espn_scoreboard_sample.json"
+
+
+def _run_cli(args: list[str]) -> subprocess.CompletedProcess[str]:
+    env = {**os.environ, "PYTHONPATH": "src"}
+    return subprocess.run(
+        [sys.executable, "-m", "cfbmeta.cli", *args],
+        capture_output=True,
+        text=True,
+        cwd=PROJECT_ROOT,
+        env=env,
+    )
+
+
+def test_cli_json_output_includes_metadata() -> None:
+    result = _run_cli([
+        "--scoreboard",
+        str(SCOREBOARD),
+        "--top",
+        "2",
+        "--format",
+        "json",
+    ])
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert "games" in payload
+    assert payload["games"], "Expected at least one game in JSON payload"
+    first = payload["games"][0]
+    for field in ("interest", "broadcasts", "summary"):
+        assert field in first
+    assert "is_favorite" in first
+
+
+def test_cli_favorite_survives_live_filter() -> None:
+    result = _run_cli([
+        "--scoreboard",
+        str(SCOREBOARD),
+        "--only-live",
+        "--top",
+        "3",
+        "--favorites",
+        "NAVY",
+    ])
+    assert result.returncode == 0, result.stderr
+    assert "★ NAVY 24 @ AF 27" in result.stdout


### PR DESCRIPTION
## Summary
- add CLI flags to control output format, emit JSON payloads, and optionally write to disk
- spotlight favorite teams in rankings while letting them bypass the live/ranked filters for quick access
- normalize serialized summaries and cover the new CLI behaviors with regression tests

## Testing
- PYTHONPATH=src python -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68cdb4a1a0d483218a01750ae88b7c33